### PR TITLE
Fixes context manger close and cleanup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vianexus_agent_sdk"
-version = "1.0.0-pre4"
+version = "1.0.0-pre5"
 authors = [
   { name="viaNexus", email="support@vianexus.com" },
 ]

--- a/src/vianexus_agent_sdk/clients/anthropic_client.py
+++ b/src/vianexus_agent_sdk/clients/anthropic_client.py
@@ -394,9 +394,9 @@ class AnthropicClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin)
                     return await self._ask_single_question_with_session(question)
                 finally:
                     # Clean up temporary session
-                    if hasattr(self, 'session') and self.session:
+                    if hasattr(self, '_exit_stack') and self._exit_stack:
                         try:
-                            await self.session.close()
+                            await self._exit_stack.aclose()
                             self.session = None
                         except Exception as e:
                             logging.debug(f"Error closing temporary session: {e}")
@@ -536,9 +536,9 @@ class AnthropicClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin)
     
     async def cleanup(self) -> None:
         """Clean up resources and close connections."""
-        if hasattr(self, 'session') and self.session:
+        if hasattr(self, '_exit_stack') and self._exit_stack:
             try:
-                await self.session.close()
+                await self._exit_stack.aclose()
             except Exception as e:
                 logging.error(f"Error closing session: {e}")
     

--- a/src/vianexus_agent_sdk/clients/gemini_client.py
+++ b/src/vianexus_agent_sdk/clients/gemini_client.py
@@ -338,9 +338,9 @@ class GeminiClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin):
                     return await self._process_query_with_session(query)
                 finally:
                     # Clean up temporary session
-                    if hasattr(self, 'session') and self.session:
+                    if hasattr(self, '_exit_stack') and self._exit_stack:
                         try:
-                            await self.session.close()
+                            await self._exit_stack.aclose()
                             self.session = None
                         except Exception as e:
                             logging.debug(f"Error closing temporary session: {e}")
@@ -475,9 +475,9 @@ class GeminiClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin):
                     return await self._ask_single_question_with_session(question)
                 finally:
                     # Clean up temporary session
-                    if hasattr(self, 'session') and self.session:
+                    if hasattr(self, '_exit_stack') and self._exit_stack:
                         try:
-                            await self.session.close()
+                            await self._exit_stack.aclose()
                             self.session = None
                         except Exception as e:
                             logging.debug(f"Error closing temporary session: {e}")
@@ -729,9 +729,9 @@ class GeminiClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin):
     
     async def cleanup(self) -> None:
         """Clean up resources and close connections."""
-        if hasattr(self, 'session') and self.session:
+        if hasattr(self, '_exit_stack') and self._exit_stack:
             try:
-                await self.session.close()
+                await self._exit_stack.aclose()
             except Exception as e:
                 logging.error(f"Error closing session: {e}")
     

--- a/src/vianexus_agent_sdk/clients/openai_client.py
+++ b/src/vianexus_agent_sdk/clients/openai_client.py
@@ -477,9 +477,9 @@ class OpenAiClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin):
                     return await self._ask_single_question_with_session(question)
                 finally:
                     # Clean up temporary session
-                    if hasattr(self, 'session') and self.session:
+                    if hasattr(self, '_exit_stack') and self._exit_stack:
                         try:
-                            await self.session.close()
+                            await self._exit_stack.aclose()
                             self.session = None
                         except Exception as e:
                             logging.debug(f"Error closing temporary session: {e}")
@@ -643,9 +643,9 @@ class OpenAiClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin):
     
     async def cleanup(self) -> None:
         """Clean up resources and close connections."""
-        if hasattr(self, 'session') and self.session:
+        if hasattr(self, '_exit_stack') and self._exit_stack:
             try:
-                await self.session.close()
+                await self._exit_stack.aclose()
             except Exception as e:
                 logging.error(f"Error closing session: {e}")
     


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces direct session-based cleanup with `_exit_stack.aclose()` checks in Anthropic, Gemini, and OpenAI clients for both per-request and final cleanup.
> 
> - **Clients (MCP cleanup)**:
>   - Use `_exit_stack.aclose()` instead of `session.close()` when tearing down temporary and final resources.
>     - `src/vianexus_agent_sdk/clients/anthropic_client.py`: update `ask_single_question` finally-block and `cleanup()` to check/use `_exit_stack`.
>     - `src/vianexus_agent_sdk/clients/gemini_client.py`: update `process_query` and `ask_single_question` finally-blocks, plus `cleanup()`.
>     - `src/vianexus_agent_sdk/clients/openai_client.py`: update `ask_single_question` finally-block and `cleanup()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 729a824470c95581c34bde56fe05e07b5628fcbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->