### PR TITLE
Pa/fixes null ref in resp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vianexus_agent_sdk"
-version = "1.0.0-pre7"
+version = "1.0.0-pre8"
 authors = [
   { name="viaNexus", email="support@vianexus.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vianexus_agent_sdk"
-version = "1.0.0-pre6"
+version = "1.0.0-pre7"
 authors = [
   { name="viaNexus", email="support@vianexus.com" },
 ]

--- a/src/vianexus_agent_sdk/clients/anthropic_client.py
+++ b/src/vianexus_agent_sdk/clients/anthropic_client.py
@@ -304,7 +304,7 @@ class AnthropicClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin)
             
             content_blocks = msg.content or []
             tool_uses = [b for b in content_blocks if getattr(b, "type", None) == "tool_use"]
-            self.messages.append({"role": "assistant", "content": msg.content})
+            self.messages.append({"role": "assistant", "content": content_blocks})
             
             if not tool_uses:
                 print()
@@ -457,7 +457,7 @@ class AnthropicClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin)
                 if getattr(block, "type", None) == "text":
                     response_content += block.text
             
-            temp_messages.append({"role": "assistant", "content": response.content})
+            temp_messages.append({"role": "assistant", "content": content_blocks})
             
             # Check for tool uses
             tool_uses = [b for b in content_blocks if getattr(b, "type", None) == "tool_use"]
@@ -524,11 +524,11 @@ class AnthropicClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin)
                     if getattr(block, "type", None) == "text":
                         response_content += block.text
                 
-                self.messages.append({"role": "assistant", "content": response.content})
+                self.messages.append({"role": "assistant", "content": content_blocks})
                 
                 # Save assistant response to memory
                 if use_memory:
-                    await self.memory_save_message("assistant", response.content)
+                    await self.memory_save_message("assistant", content_blocks)
                 
                 # Check for tool uses
                 tool_uses = [b for b in content_blocks if getattr(b, "type", None) == "tool_use"]

--- a/src/vianexus_agent_sdk/clients/anthropic_client.py
+++ b/src/vianexus_agent_sdk/clients/anthropic_client.py
@@ -302,7 +302,8 @@ class AnthropicClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin)
                 
                 msg = await stream.get_final_message()
             
-            tool_uses = [b for b in msg.content if getattr(b, "type", None) == "tool_use"]
+            content_blocks = msg.content or []
+            tool_uses = [b for b in content_blocks if getattr(b, "type", None) == "tool_use"]
             self.messages.append({"role": "assistant", "content": msg.content})
             
             if not tool_uses:
@@ -451,14 +452,15 @@ class AnthropicClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin)
             )
             
             # Extract text content
-            for block in response.content:
+            content_blocks = response.content or []
+            for block in content_blocks:
                 if getattr(block, "type", None) == "text":
                     response_content += block.text
             
             temp_messages.append({"role": "assistant", "content": response.content})
             
             # Check for tool uses
-            tool_uses = [b for b in response.content if getattr(b, "type", None) == "tool_use"]
+            tool_uses = [b for b in content_blocks if getattr(b, "type", None) == "tool_use"]
             
             if not tool_uses:
                 break
@@ -517,7 +519,8 @@ class AnthropicClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin)
                 )
                 
                 # Extract text content
-                for block in response.content:
+                content_blocks = response.content or []
+                for block in content_blocks:
                     if getattr(block, "type", None) == "text":
                         response_content += block.text
                 
@@ -528,7 +531,7 @@ class AnthropicClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin)
                     await self.memory_save_message("assistant", response.content)
                 
                 # Check for tool uses
-                tool_uses = [b for b in response.content if getattr(b, "type", None) == "tool_use"]
+                tool_uses = [b for b in content_blocks if getattr(b, "type", None) == "tool_use"]
                 
                 if not tool_uses:
                     break

--- a/src/vianexus_agent_sdk/clients/gemini_client.py
+++ b/src/vianexus_agent_sdk/clients/gemini_client.py
@@ -382,7 +382,8 @@ class GeminiClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin):
                 # Check if the response contains content, to prevent NoneType error
                 if response.candidates and response.candidates[0].content:
                     # Check if the model is calling a tool
-                    tool_calls = [p.function_call for p in response.candidates[0].content.parts if hasattr(p, 'function_call') and p.function_call]
+                    content_parts = response.candidates[0].content.parts or []
+                    tool_calls = [p.function_call for p in content_parts if hasattr(p, 'function_call') and p.function_call]
 
                     if tool_calls:
                         # Add the model's response to the history (preserving function calls for context)
@@ -514,7 +515,8 @@ class GeminiClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin):
                 
                 # Check for tool calls
                 if response.candidates and response.candidates[0].content:
-                    tool_calls = [p.function_call for p in response.candidates[0].content.parts if hasattr(p, 'function_call') and p.function_call]
+                    content_parts = response.candidates[0].content.parts or []
+                    tool_calls = [p.function_call for p in content_parts if hasattr(p, 'function_call') and p.function_call]
                     if not tool_calls:
                         break
                     
@@ -598,7 +600,8 @@ class GeminiClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin):
                             await self.memory_save_message("assistant", response.text)
                         
                         # Check for tool calls
-                        tool_calls = [p.function_call for p in response.candidates[0].content.parts if hasattr(p, 'function_call') and p.function_call]
+                        content_parts = response.candidates[0].content.parts or []
+                        tool_calls = [p.function_call for p in content_parts if hasattr(p, 'function_call') and p.function_call]
                         
                         if not tool_calls:
                             break
@@ -644,7 +647,8 @@ class GeminiClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin):
             A new Content object with text and function call parts, or None if no relevant parts found
         """
         relevant_parts = []
-        for part in response_content.parts:
+        content_parts = response_content.parts or []
+        for part in content_parts:
             # Include text parts
             if hasattr(part, 'text') and part.text:
                 relevant_parts.append(genai.types.Part.from_text(text=part.text))

--- a/src/vianexus_agent_sdk/clients/gemini_client.py
+++ b/src/vianexus_agent_sdk/clients/gemini_client.py
@@ -661,8 +661,15 @@ class GeminiClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin):
         gemini_messages = []
         
         for msg in memory_messages:
-            role = msg.get("role", "user")
-            content = msg.get("content", "")
+            # Handle both UniversalMessage objects and dict formats
+            if hasattr(msg, 'role'):
+                # UniversalMessage object
+                role = msg.role.value if hasattr(msg.role, 'value') else str(msg.role)
+                content = msg.content
+            else:
+                # Dictionary format (fallback)
+                role = msg.get("role", "user")
+                content = msg.get("content", "")
             
             # Map roles to Gemini format
             if role == "assistant":

--- a/src/vianexus_agent_sdk/clients/gemini_client.py
+++ b/src/vianexus_agent_sdk/clients/gemini_client.py
@@ -520,8 +520,9 @@ class GeminiClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin):
                     if not tool_calls:
                         break
                     
-                    # Add model response to temp conversation
-                    temp_messages.append(response.candidates[0].content)
+                    # Add model response to temp conversation (only if content exists)
+                    if response.candidates[0].content:
+                        temp_messages.append(response.candidates[0].content)
                     # Execute tools
                     tool_results = await self._execute_tool_calls(tool_calls)
                     temp_messages.append(genai.types.Content(role="user", parts=tool_results))


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds None-safe handling of response content/parts in Anthropic and Gemini clients and bumps version to 1.0.0-pre8.
> 
> - **Clients**:
>   - **`src/vianexus_agent_sdk/clients/anthropic_client.py`**:
>     - Safely handle `msg.content`/`response.content` via `content_blocks = ... or []` before iterating and extracting text/tool uses in streaming, single-question, and history flows.
>   - **`src/vianexus_agent_sdk/clients/gemini_client.py`**:
>     - Safely handle `content.parts` via `content_parts = ... or []` when extracting function calls and text, including in single-question, history flows, and `_extract_text_only_content`.
> - **Version**:
>   - Bump `pyproject.toml` `version` to `1.0.0-pre8`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7832eb0890b455de7af5a81d2d125d6793210eb0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->